### PR TITLE
Pytest for upstream guide

### DIFF
--- a/will/tests/conftest.py
+++ b/will/tests/conftest.py
@@ -6,7 +6,6 @@ from will.abstractions import Message, Person
 # discovered tests.
 # https://docs.pytest.org/en/latest/fixture.html#conftest-py-sharing-fixture-functions
 
-
 @pytest.fixture()
 def person():
     """Mimic person abstraction"""

--- a/will/tests/conftest.py
+++ b/will/tests/conftest.py
@@ -6,6 +6,7 @@ from will.abstractions import Message, Person
 # discovered tests.
 # https://docs.pytest.org/en/latest/fixture.html#conftest-py-sharing-fixture-functions
 
+
 @pytest.fixture()
 def person():
     """Mimic person abstraction"""

--- a/will/tests/conftest.py
+++ b/will/tests/conftest.py
@@ -2,6 +2,10 @@ import pytest
 
 from will.abstractions import Message, Person
 
+# Any fixtures defined in this file will be automatically imported into
+# discovered tests.
+# https://docs.pytest.org/en/latest/fixture.html#conftest-py-sharing-fixture-functions
+
 
 @pytest.fixture()
 def person():


### PR DESCRIPTION
Hey @chillipeper. I dunno if this is a sane way to try to piggyback on your work but here goes. I spent some time reading through your tests and reading through the pytest docs and just went in and sprinkled some commentary. I'm hoping this will help me and perhaps some of the other contributors wrap our heads around how pytest does things. I don't think we need to aim for this level of commentary in all our tests, just to get us started. If I've misunderstood something and added some misleading comments please let me know.

Other than that there's one thing I don't understand, and one thing that I think could be made clearer (although more verbose).

The thing I don't understand is, why `yield` from `settings_acl`? From my (admittedly brief) reading of the pytest docs `yield` seems to be related to teardown code. Is there some other use here I'm missing?

With respect to clarity/verbosity, I think the list comprehension to build up the mappings of users and groups are a bit gnarly. If somebody comes into this file looking to fix a failing test it will take some mental unpacking just to work out the structure of the data being passed to the test functions. I know it's clunkier but I think it's much easier to understand this test by looking at something like this.

```
ACL = {
 'ENGINEERING_OPS': ['bob', 'Alice'],
 'engineering_devs': ['eve']
}

VALID_USERS_AND_GROUPS =[
 ('bob', {'ENGINEERING_OPS'}),
 ('Alice', {'ENGINEERING_OPS'}),
 ('eve', {'engineering_devs'}),
 ('bob', {'ENGINEERING_OPS', 'engineering_devs'}),
 ('Alice', {'ENGINEERING_OPS', 'engineering_devs'}),
 ('eve', {'ENGINEERING_OPS', 'engineering_devs'})
]

INVALID_USERS_AND_GROUPS = [
 ('bob', {'engineering_devs'}),
 ('Alice', {'engineering_devs'}),
 ('eve', {'ENGINEERING_OPS'}),
 ('juan', {'ENGINEERING_OPS', 'engineering_devs'}),
 ('pedro', {'ENGINEERING_OPS', 'engineering_devs'})
]
```

With it spelled out like that we could still use the list comprehension to build the `ids` list up without obscuring the structure of the test data. What do you think, too gross?

