### PR TITLE
Params in config.py should not override ENV vars

### DIFF
--- a/will/settings.py
+++ b/will/settings.py
@@ -113,7 +113,8 @@ def import_settings(quiet=True):
                         warn("%s is set in the environment as '%s', but overridden in"
                              " config.py as '%s'." % (k, os.environ[k], v))
                         had_warning = True
-                    settings[k] = v
+                    if k not in settings:
+                        settings[k] = v
 
             if not had_warning and not quiet:
                 show_valid("Valid.")


### PR DESCRIPTION
In the current setup, first all env vars are fetched started with `WILL_` in `settings`, then all values from `config.py` are populated in `settings` which overrides any key already set using ENV var.

Usually all default configs should be kept in `config.py` and ENV vars should be used to override any params. This is much needed feature in docker world, where secure credentials are always passed as ENV vars along with any other vars if needed.